### PR TITLE
Fix SwiftBoxDemo

### DIFF
--- a/SwiftBoxDemo/SwiftBoxDemo/AppDelegate.swift
+++ b/SwiftBoxDemo/SwiftBoxDemo/AppDelegate.swift
@@ -14,8 +14,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	@IBOutlet weak var window: NSWindow!
 
 	func applicationDidFinishLaunching(notification: NSNotification) {
-		let contentView = window.contentView as NSView
+		let contentView = window.contentView as! NSView
 		let parent = Node(size: contentView.frame.size,
+                          direction: .Row,
                           childAlignment: .Center,
                           children: [
 			Node(flex: 75,


### PR DESCRIPTION
The demo needs to be updated for Swift 1.2 and it seems like maybe `direction: .Row` was default before but now it's not, so you got a 0-width column.